### PR TITLE
fix emit-map->field to correctly set false values

### DIFF
--- a/test/ib_re_actor/test/mapping.clj
+++ b/test/ib_re_actor/test/mapping.clj
@@ -153,7 +153,7 @@ You can have duplicate rows for the same field<->map key to try out different va
   [:order-id m_orderId 1]
   [:client-id m_clientId 2]
   [:permanent-id m_permId 3]
-  [:transmit? m_transmit true]
+  [:transmit? m_transmit false]
   [:quantity m_totalQuantity 4]
   [:action m_action :buy "BUY"]
   [:type m_orderType :limit "LMT"]


### PR DESCRIPTION
Fixes a bug where `defmapping` would not allow for a field to be set to a falsey value. I ran into this on trying to create orders where `transmit?` would be set to false. 