### PR TITLE
Support additional contracts

### DIFF
--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -801,7 +801,8 @@ to check if if a given value is valid (known)."
    "CST" "America/Chicago"
    "CTT" "America/Chicago"
    "JST" "Asia/Tokyo"
-   "PST" "America/Los_Angeles"})
+   "PST" "America/Los_Angeles"
+   "IST" "Asia/Kolkata"})
 
 (defn- to-utc
   "Returns a full date-time in UTC, referring to a particular time at a

--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -117,7 +117,8 @@ to check if if a given value is valid (known)."
                     :bag           "BAG"
                     :warrant       "WAR"
                     :dutch-warrant "IOPT"
-                    :cfd           "CFD"})
+                    :cfd           "CFD"
+                    :commodity     "CMDTY"})
 
 (defmethod translate [:to-ib :bar-size-unit] [_ _ unit]
   (case unit

--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -853,3 +853,10 @@ to check if if a given value is valid (known)."
        (map th-components)
        (mapcat th-intervals)
        (map (partial joda-interval tz))))
+
+(defmethod translate [:from-ib :security-id-list] [_ _ tag-values]
+  (when tag-values
+    (into {}
+          (for [tag-value tag-values]
+            [(translate :from-ib :security-id-type (.m_tag tag-value))
+             (.m_value tag-value)]))))

--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -758,10 +758,11 @@ to check if if a given value is valid (known)."
     (expiry-to-ib val)))
 
 (defmethod translate [:from-ib :expiry] [_ _ val]
-  (condp = (.length val)
-    6 (org.joda.time.YearMonth.
-       (tf/parse-local-date (tf/formatter "yyyyMM") val))
-    8 (tf/parse-local-date (tf/formatter "yyyyMMdd") val)))
+  (if (= val "NOEXP") nil
+      (condp = (.length val)
+        6 (org.joda.time.YearMonth.
+           (tf/parse-local-date (tf/formatter "yyyyMM") val))
+        8 (tf/parse-local-date (tf/formatter "yyyyMMdd") val))))
 
 (defmethod translate [:to-ib :bar-size] [_ _ [val unit]]
   (str val " " (translate :to-ib :bar-size-unit unit)))

--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -108,13 +108,16 @@ to check if if a given value is valid (known)."
     :years [val :years]))
 
 (translation-table security-type
-                   {:equity "STK"
-                    :option "OPT"
-                    :future "FUT"
-                    :index "IND"
+                   {:equity        "STK"
+                    :option        "OPT"
+                    :future        "FUT"
+                    :index         "IND"
                     :future-option "FOP"
-                    :cash "CASH"
-                    :bag "BAG"})
+                    :cash          "CASH"
+                    :bag           "BAG"
+                    :warrant       "WAR"
+                    :dutch-warrant "IOPT"
+                    :cfd           "CFD"})
 
 (defmethod translate [:to-ib :bar-size-unit] [_ _ unit]
   (case unit

--- a/src/ib_re_actor/wrapper.clj
+++ b/src/ib_re_actor/wrapper.clj
@@ -274,13 +274,16 @@
 
     ;;; Contract Details
     (contractDetails [this requestId contractDetails]
-      (let [{:keys [trading-hours liquid-hours time-zone-id] :as m} (->map contractDetails)
+      (let [{:keys[trading-hours liquid-hours time-zone-id
+                   security-id-list] :as m} (->map contractDetails)
             th (translate :from-ib :trading-hours [time-zone-id trading-hours])
-            lh (translate :from-ib :trading-hours [time-zone-id liquid-hours])]
-        (dispatch-message cb {:type :contract-details :request-id requestId
+            lh (translate :from-ib :trading-hours [time-zone-id liquid-hours])
+            sids (translate :from-ib :security-id-list security-id-list)]
+        (dispatch-message cb {:type  :contract-details :request-id requestId
                               :value (merge m
                                             (when th {:trading-hours th})
-                                            (when lh {:liquid-hours lh}))})))
+                                            (when lh {:liquid-hours lh})
+                                            (when sids {:security-id-list sids}))})))
 
     (contractDetailsEnd [this requestId]
       (dispatch-message cb {:type :contract-details-end :request-id requestId}))


### PR DESCRIPTION
I've been experimenting with blindly importing a large number of IB's contracts and have discovered a few small bugs. There might be more to come :)

IB uses IST to abbreviate "India Standard Time" in their timezone ids. This is not an official timezone abbreviation that's recognized by Jodatime. 
https://stackoverflow.com/questions/11264697/java-timezone-strange-behavior-with-ist
https://en.wikipedia.org/wiki/Time_in_India

IB has an IOPT contract type, aka a Dutch Warrant. They have a "NOEXP" expiry value which was breaking with the current expiry translation function.
More info on them here:
https://money.stackexchange.com/questions/7016/interactive-brokers-iopts-and-list-of-structured-products